### PR TITLE
List gemini models using Google API

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "@anthropic-ai/sdk": "^0.39.0",
     "@aws-sdk/client-bedrock": "^3.787.0",
     "@aws-sdk/client-bedrock-runtime": "^3.785.0",
-    "@google/genai": "^0.9.0",
+    "@google/genai": "^0.13.0",
     "@modelcontextprotocol/sdk": "^1.7.0",
     "@types/react": "^19.0.12",
     "@types/react-dom": "^19.0.4",

--- a/src/main/llm/geminiLLM.ts
+++ b/src/main/llm/geminiLLM.ts
@@ -209,8 +209,8 @@ export class GeminiLLM implements ILLM {
     for await (const model of models) {
       const newModel: ILLMModel = {
         provider: LLMType.Gemini,
-        // May not need to remove the model/ prefix here in case you like it
-        id: model.name ? model.name.replace(/^model\//, '') : '',
+        // May not need to remove the models/ prefix here in case you like it
+        id: model.name ? model.name.replace(/^models\//, '') : '',
         name: model.displayName ?? '',
         description: model.description || '',
         modelSource: 'Google'


### PR DESCRIPTION
It looks like updating to 0.13 of the Google genai magic will deliver the model list API and resolve https://github.com/googleapis/js-genai/issues/473

The list of models returned by Google is long and distinguished and may benefit from filtering, sorting or searching.